### PR TITLE
docs: update README, DEVELOPMENT, and ADDING-A-LOCALE to reflect i18n…

### DIFF
--- a/ADDING-A-LOCALE.md
+++ b/ADDING-A-LOCALE.md
@@ -1,10 +1,8 @@
 # Adding a New Locale to the Xahau Website
 
-The Xahau website supports multiple languages through Astro's built-in i18n system. Content is driven by JSON data files and a small set of translation keys, making it straightforward to add a new language without touching component logic.
+The Xahau website supports multiple languages through Astro's directory-based i18n. Editorial pages are single components per page that pull their copy from per-page translation tables in `src/i18n/`, so adding a language is mostly a matter of adding new entries to those tables and creating a `src/pages/<locale>/` folder of thin route wrappers.
 
 The site currently ships with English (default), Spanish (`es`), and Japanese (`ja`).
-
-To add a new language, you need to update a handful of files — configuration, translation keys, data files, and page routes. The steps below walk through each one.
 
 For a worked example, see the [Brazilian Portuguese (pt-BR) guide](#example-brazilian-portuguese-pt-br) at the end of this document.
 
@@ -14,17 +12,21 @@ For a worked example, see the [Brazilian Portuguese (pt-BR) guide](#example-braz
 
 | File | What to do |
 |------|-----------|
-| `astro.config.mjs` | Register the new locale |
-| `src/i18n/indexTranslations.ts` | Add home page translation keys |
-| `src/i18n/fraudReportTranslations.ts` | Add fraud report page translations |
-| `src/data/about.json` | Translate about page content |
-| `src/data/ecosystem.json` | Translate ecosystem section labels |
-| `src/data/home.json` | Translate stats tile labels |
-| `src/data/features.json` | Translate features content |
-| `src/data/connect.json` | Translate connect/events labels |
+| `src/i18n/locales.ts` | Add the locale code to the `locales` array |
+| `astro.config.mjs` | Register the locale with Starlight (for the `/docs` section) |
+| `src/i18n/indexTranslations.ts` | Add a locale block (home page copy) |
+| `src/i18n/aboutTranslations.ts` | Add a locale block (About page copy) |
+| `src/i18n/featuresTranslations.ts` | Add a locale block (Features page copy) |
+| `src/i18n/contestTranslations.ts` | Add a locale block (Contest page copy) |
+| `src/i18n/fraudReportTranslations.ts` | Add a locale block (Fraud Report form) |
+| `src/data/home.json` | Translate stat tile labels |
+| `src/data/connect.json` | Translate event labels |
+| `src/data/roadmap.json` | Translate roadmap titles/descriptions |
+| `src/data/ecosystem.json` | Translate section labels, taglines, and the `trademark` disclaimer |
+| `src/CookieConsentConfig.ts` | Add a `translations` block for the cookie banner |
 | `src/pages/<locale>/` | Create page routes (copy from `es/`) |
-| `src/components/XahauAbout<Locale>.astro` | Create localised about component |
-| `src/components/XahauEcosystem.astro` | Add locale to TM disclaimer |
+
+There is **no per-locale component to create.** A single `XahauAbout.astro`, `XahauFeatures.astro`, etc. handles every locale by reading from the matching translation table.
 
 ---
 
@@ -34,9 +36,25 @@ The locale code to use throughout is `pt-BR`.
 
 ---
 
-### Step 1 — `astro.config.mjs`
+### Step 1 — `src/i18n/locales.ts`
 
-Find the `locales` block and add the new entry:
+Add the new locale to the `locales` tuple. Everything downstream (the `Locale` type, `nonDefaultLocales` array, and per-component lookups) updates automatically.
+
+```ts
+export const locales = ['en', 'es', 'ja', 'pt-BR'] as const
+export type Locale = (typeof locales)[number]
+
+export const defaultLocale = 'en'
+export const nonDefaultLocales = locales.filter(
+  (locale) => locale !== defaultLocale,
+)
+```
+
+---
+
+### Step 2 — `astro.config.mjs`
+
+This step is only needed if you want the `/docs` section translated as well. The Starlight `locales` block lives inside the `starlight({...})` integration:
 
 ```js
 locales: {
@@ -47,12 +65,13 @@ locales: {
 },
 ```
 
+The editorial pages do not need any Astro config change — they pick the new locale up automatically once `src/pages/pt-BR/` exists (Step 9).
+
 ---
 
-### Step 2 — `src/i18n/indexTranslations.ts`
+### Step 3 — `src/i18n/indexTranslations.ts`
 
-Add a `'pt-BR'` block before the closing `}` of the `indexTranslations` object.
-Copy the structure below and fill in the translations (English originals shown as comments):
+Add a `'pt-BR'` block before the closing `}` of the `indexTranslations` object. Copy the `en` block and translate every value (English originals shown as comments below for reference):
 
 ```ts
 'pt-BR': {
@@ -78,121 +97,39 @@ Copy the structure below and fill in the translations (English originals shown a
 },
 ```
 
-Also update the type at the bottom of the file:
-```ts
-export type IndexLocale = keyof typeof indexTranslations
-```
-This updates automatically — no change needed if you added the block above correctly.
+---
+
+### Step 4 — `src/i18n/aboutTranslations.ts`
+
+Add a `'pt-BR'` block to `aboutTranslations`. Mirror the structure of the existing `en` block — page header (`page_title`, `page_subtitle`, `chip1`–`chip4`) followed by the three thematic acts (Network, Protocol, Currency) with their `actN_*` keys.
+
+The English chips are: `Est. October 2023`, `200k+ Accounts`, `~4s Settlement`, `10k tx / ledger`.
 
 ---
 
-### Step 3 — `src/i18n/fraudReportTranslations.ts`
+### Step 5 — `src/i18n/featuresTranslations.ts`
 
-Update the type at the top:
-```ts
-export type FraudReportLocale = 'en' | 'es' | 'ja' | 'pt-BR'
-```
-
-Then add a `'pt-BR'` block to `fraudReportTranslations`. English originals are shown below — translate all values:
-
-```ts
-'pt-BR': {
-  frontmatter: {
-    title: '', // 'Report Fraud'
-    description: '', // 'Have you been scammed or hacked? Here is what to do!'
-  },
-  intro: {
-    body: '', // 'Xahau is a public blockchain, with no governing party that can freeze or retrieve funds, close accounts, or otherwise keep people from their assets.'
-    warning: '', // "We can't reverse or cancel transactions, no-one can."
-    lead: '', // 'We can flag accounts used for illicit activity, which will:'
-    bullets: [
-      '', // 'Be included in our API that exchanges and other entities are using for AML compliance to monitor deposits, and possibly withhold illicit funds.'
-      '', // 'Movement of funds will be auto-traced and we will receive notifications whenever they move, no matter how old the case is.'
-      '', // 'In case of a scam, warn other users through wallet software and exchanges using our API, not to send funds to a flagged account.'
-    ],
-    steps: [
-      {
-        title: '', // '1. Submit the address to Xahau Forensics'
-        body: '', // 'We maintain the largest fraudulent address registry on Xahau and it is used by several entities to combat illicit activity.'
-      },
-      {
-        title: '', // '2. Report your case to law enforcement'
-        body: '', // 'Report it to the local police and if your country has an online report form for cybercrime or financial crime, report it there as well.'
-      },
-      {
-        title: '', // '3. Follow up on your police report'
-        body: '', // 'We work with law enforcement. Let them know that we have the information. The odds are that we are also in contact with other victims and can help law enforcement combine cases across jurisdictions and provide actionable intelligence.'
-      },
-    ],
-    expectationTitle: '', // 'What can you expect?'
-    expectations: [
-      '', // "We can't reverse or cancel transactions, no-one can."
-      '', // 'We do our best to have funds seized when they leave Xahau, by working with exchanges and other off ramps through our fraudulent address registry API and by manually making contact.'
-      '', // 'When you report an account to us, you can expect us to treat your report with as much attention as any other report.'
-      '', // 'We get many reports every single day. If an account is added to our fraudulent address registry, we are taking the best care of it along with all other cases.'
-      '', // 'If money is seized we will contact you, if you have left us a way to contact you.'
-      '', // 'To reclaim funds you have to work with law enforcement for paperwork.'
-    ],
-    expectationWarning: '', // "We monitor hundreds of cases at the same time and can't hold hands on a case-by-case basis. We will only contact you if we have good news!"
-  },
-  form: {
-    successTitle: '', // 'Success!'
-    successBody: '', // 'Thank you for your report. It has been submitted successfully.'
-    reportIdLabel: '', // 'Report ID:'
-    reportIdFallback: '', // 'unknown'
-    errorTitle: '', // 'Error'
-    addressLabel: '', // 'Xahau Address'
-    addressPlaceholder: 'rXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
-    addressHint: '', // 'Enter the Xahau address associated with the fraudulent activity'
-    descriptionLabel: '', // 'Description'
-    descriptionPlaceholder: '', // 'Describe the fraudulent activity'
-    descriptionHint: '', // 'Provide as much detail as possible to help us investigate'
-    urlLabel: 'URL',
-    urlPlaceholder: '', // 'Optional URL related to the fraud'
-    urlHint: '', // 'Provide a URL if relevant, for example a scam website or social media post'
-    categoryLabel: '', // 'Suggested Category'
-    categoryPlaceholder: '', // 'Select a category...'
-    categoryOptions: [
-      { value: 'giveaway', label: '' }, // 'Giveaway'
-      { value: 'theft', label: '' },    // 'Theft'
-      { value: 'other', label: '' },    // 'Other'
-    ],
-    categoryHint: '', // 'Help us categorize the type of fraud'
-    contactLabel: '', // 'Contact Information'
-    contactPlaceholder: '', // 'Optional contact information, for example e-mail, X handle or Telegram username'
-    contactHint: '', // "Provide contact info if you're willing to help with follow-up questions"
-    requiredFields: '', // 'Required fields'
-    submitLabel: '', // 'Submit Report'
-    submitAnotherLabel: '', // 'Submit Another Report'
-    optional: '', // 'Optional'
-  },
-  privacy: {
-    title: '', // 'Privacy & Security'
-    bullets: [
-      '', // "This form uses ALTCHA, a privacy-compliant CAPTCHA that doesn't track you"
-      '', // 'Your report is submitted securely to the Xahau Forensics network'
-      '', // 'Reports are reviewed and used to improve network security'
-      '', // 'No personal information is required to submit a report'
-    ],
-  },
-  attribution: {
-    prefix: '', // 'Xahau Forensics is run by '
-    label: 'INFTF',
-    suffix: '.', // '.'
-  },
-  messages: {
-    captchaIncomplete: '', // 'Please complete the CAPTCHA verification before submitting.'
-    captchaFailed: '', // 'CAPTCHA verification failed. Please complete the challenge and try again.'
-    submitting: '', // 'Submitting...'
-    submitFailed: '', // 'Failed to submit report. Please try again.'
-    networkError: '', // 'Network error: Unable to connect to the server. Please check your connection and try again.'
-  },
-},
-```
+Add a `'pt-BR'` block. The structure mirrors `en`: page header (`page_title`, `page_subtitle`, `chip1`–`chip4`), then the three acts — Protocol Layer, Finance, Governance — with `proto_*`, `dex_*`, `nft_*`, etc. keys for each feature inside.
 
 ---
 
-### Step 4 — `src/data/ecosystem.json`
+### Step 6 — `src/i18n/contestTranslations.ts`
+
+Add a `'pt-BR'` block mirroring the `en` block (page subtitle, chips, and the contest acts).
+
+---
+
+### Step 7 — `src/i18n/fraudReportTranslations.ts`
+
+`fraudReportTranslations` is typed as `Record<Locale, FraudReportTranslations>`, so once Step 1 adds `pt-BR` to `Locale`, TypeScript will refuse to compile until this file has a matching block.
+
+Add a `'pt-BR'` block mirroring the existing `en` block. It has six sub-sections — `frontmatter`, `intro`, `form`, `privacy`, `attribution`, `messages`. Every string needs translating; structural keys like `addressPlaceholder: 'rXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'` and `urlLabel: 'URL'` can stay as-is.
+
+> **Note:** `aboutTranslations`, `featuresTranslations`, `contestTranslations`, and `indexTranslations` are not bound to `Record<Locale, …>` — TypeScript will not flag a missing locale block in those files. Use the [Checklist](#checklist) at the bottom of this guide to make sure none are missed.
+
+---
+
+### Step 8 — `src/data/ecosystem.json`
 
 Add `"pt-BR"` to every `label` and `tagline` object. English originals shown:
 
@@ -210,14 +147,22 @@ Add `"pt-BR"` to every `label` and `tagline` object. English originals shown:
 - Explorers: `"pt-BR": "Inspecione e interaja com o ledger"`
 - Projects: `"pt-BR": "Apps, ferramentas e experiências construídas no Xahau"`
 
-**CTA tile label** (in `home.json`):
-- `"pt-BR": "Quer rodar um nó?"`
+**Trademark disclaimer** (top-level `trademark` object — this is the new home of the disclaimer, no component change needed):
+
+```json
+"trademark": {
+  "en": "All trademarks and logos are the property of their respective owners.",
+  "es": "Todas las marcas y logotipos son propiedad de sus respectivos dueños.",
+  "ja": "すべての商標およびロゴは、各所有者に帰属します",
+  "pt-BR": "Todas as marcas e logotipos são propriedade de seus respectivos donos."
+}
+```
 
 ---
 
-### Step 5 — `src/data/home.json`
+### Step 9 — `src/data/home.json`
 
-Add `"pt-BR"` to every stat tile `label`. English originals:
+Add `"pt-BR"` to every stat tile `label`, including the CTA tile. English originals:
 
 ```json
 "pt-BR": "Ledgers fechados"        // Ledgers closed
@@ -231,32 +176,21 @@ Add `"pt-BR"` to every stat tile `label`. English originals:
 
 ---
 
-### Step 6 — `src/data/about.json`
+### Step 10 — `src/data/connect.json` and `src/data/roadmap.json`
 
-Add `"pt-BR"` chips arrays and body text for all three locale sections. The chips to translate:
+Each event in `connect.json` has `dateLabel`, `title`, `location`, and `registration.label` objects keyed by locale — add `"pt-BR"` entries to all of them.
 
-- `"Est. outubro de 2023"` (Est. October 2023)
-- `"200k+ Contas"` (200k+ Accounts)
-- `"~4s Liquidação"` (~4s Settlement)
-- `"10k tx / ledger"` (keep as-is, technical term)
-
-The body paragraphs and timeline entries are longer — use the English text in the file as source.
+Each item in `roadmap.json` has `title` and `description` objects keyed by locale — add `"pt-BR"` to every entry. Also add the locale to any `labels` block at the top of the file used by `XahauRoadmap.astro`.
 
 ---
 
-### Step 7 — `src/data/features.json`
+### Step 11 — `src/CookieConsentConfig.ts`
 
-Add `"pt-BR"` translations to all feature titles and descriptions. Use the English text as source.
-
----
-
-### Step 8 — `src/data/connect.json`
-
-Add `"pt-BR"` translations to all event label fields. Use the English text as source.
+Add a `'pt-BR'` block to the `language.translations` object, mirroring the existing `en` block (`consentModal` strings + `preferencesModal` strings). The cookie banner picks the active locale up automatically once this block exists.
 
 ---
 
-### Step 9 — `src/pages/pt-BR/`
+### Step 12 — `src/pages/pt-BR/`
 
 Create a new folder `src/pages/pt-BR/` and copy all files from `src/pages/es/`:
 
@@ -272,44 +206,26 @@ src/pages/pt-BR/privacy-policy.mdx
 src/pages/pt-BR/roadmap.astro
 ```
 
-In each `.astro` file, the only change needed is the component import — replace `XahauAboutEs` with `XahauAboutPtBR` in `about.astro`. All other pages use the shared locale-aware components and need no changes.
+In each `.astro` file, only the `_frontmatter` `title` and `description` need translating — the component imports stay unchanged because the editorial components are locale-agnostic.
 
 For `index.mdx` and `privacy-policy.mdx`, translate the MDX content directly.
 
 ---
 
-### Step 10 — `src/components/XahauAboutPtBR.astro`
-
-Copy `src/components/XahauAboutEs.astro` and rename it `XahauAboutPtBR.astro`. Translate all hardcoded text strings inside the file (headings, body paragraphs, chip labels).
-
----
-
-### Step 11 — `src/components/XahauEcosystem.astro`
-
-Find the TM disclaimer ternary and add the `pt-BR` case:
-
-```astro
-{locale === 'es'
-  ? 'Todas las marcas y logotipos son propiedad de sus respectivos dueños.'
-  : locale === 'ja'
-  ? 'すべての商標およびロゴは、各所有者に帰属します'
-  : locale === 'pt-BR'
-  ? 'Todas as marcas e logotipos são propriedade de seus respectivos donos.'
-  : 'All trademarks and logos are the property of their respective owners.'}
-```
-
----
-
 ## Checklist
 
-- [ ] `astro.config.mjs` — locale added
+- [ ] `src/i18n/locales.ts` — locale code added to `locales` tuple
+- [ ] `astro.config.mjs` — Starlight `locales` updated (only if `/docs` is being translated)
 - [ ] `src/i18n/indexTranslations.ts` — `pt-BR` block added
+- [ ] `src/i18n/aboutTranslations.ts` — `pt-BR` block added
+- [ ] `src/i18n/featuresTranslations.ts` — `pt-BR` block added
+- [ ] `src/i18n/contestTranslations.ts` — `pt-BR` block added
 - [ ] `src/i18n/fraudReportTranslations.ts` — type updated, `pt-BR` block added
-- [ ] `src/data/ecosystem.json` — all labels and taglines
+- [ ] `src/data/ecosystem.json` — labels, taglines, and `trademark` updated
 - [ ] `src/data/home.json` — all stat labels
-- [ ] `src/data/about.json` — chips and body text
-- [ ] `src/data/features.json` — all features
-- [ ] `src/data/connect.json` — all labels
-- [ ] `src/pages/pt-BR/` — folder created, all pages copied
-- [ ] `src/components/XahauAboutPtBR.astro` — created and translated
-- [ ] `src/components/XahauEcosystem.astro` — TM disclaimer updated
+- [ ] `src/data/connect.json` — event labels
+- [ ] `src/data/roadmap.json` — item titles, descriptions, header labels
+- [ ] `src/CookieConsentConfig.ts` — `translations.pt-BR` block added
+- [ ] `src/pages/pt-BR/` — folder created, all pages copied, frontmatter translated
+- [ ] `src/pages/pt-BR/index.mdx` and `privacy-policy.mdx` — content translated
+- [ ] `npm run check` passes

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,22 +6,35 @@ Reference documentation for working on the Xahau website codebase. See [README.m
 
 ## Editorial Component System
 
-Marketing pages (About, Features, Connect, Contest, Home, Roadmap) use a custom editorial component system — **not** Markdown/MDX. Each page is a self-contained `.astro` component inside `src/components/`.
+Marketing pages (About, Features, Connect, Contest, Home, Roadmap, Ecosystem) use a custom editorial component system — **not** Markdown/MDX. Each page is a self-contained `.astro` component inside `src/components/`, and there is exactly **one component per page** for all locales — locale-specific copy is fetched from translation tables in `src/i18n/`.
 
 ### Component map
 
-| URL | Component(s) |
-| :-- | :----------- |
-| `/` | `IndexLayout.astro` → `XahauHome.astro` |
-| `/about` | `XahauAbout.astro` / `XahauAboutEs.astro` / `XahauAboutJa.astro` |
-| `/features` | `XahauFeatures.astro` / `XahauFeaturesEs.astro` / `XahauFeaturesJa.astro` |
-| `/connect` | `XahauConnect.astro` |
-| `/contest` | `XahauContest.astro` / `XahauContestEs.astro` / `XahauContestJa.astro` |
-| `/roadmap` | `XahauRoadmap.astro` |
-| `/ecosystem` | `XahauEcosystem.astro` |
-| `/fraud-report` | `FraudReportPage.astro` |
+| URL | Component | Source of copy |
+| :-- | :-------- | :------------- |
+| `/` | `XahauHome.astro` | `src/i18n/indexTranslations.ts` + `src/data/home.json` (stat numbers) |
+| `/about` | `XahauAbout.astro` | `src/i18n/aboutTranslations.ts` |
+| `/features` | `XahauFeatures.astro` | `src/i18n/featuresTranslations.ts` |
+| `/contest` | `XahauContest.astro` | `src/i18n/contestTranslations.ts` |
+| `/connect` | `XahauConnect.astro` | `src/data/connect.json` |
+| `/roadmap` | `XahauRoadmap.astro` | `src/data/roadmap.json` |
+| `/ecosystem` | `XahauEcosystem.astro` | `src/data/ecosystem.json` |
+| `/fraud-report` | `FraudReportPage.astro` | `src/i18n/fraudReportTranslations.ts` |
 
-Each component lives in `src/components/` and is imported by a thin page wrapper in `src/pages/` (and `src/pages/es/`, `src/pages/ja/`).
+Each component lives in `src/components/` and is imported by a thin page wrapper in `src/pages/` (and `src/pages/es/`, `src/pages/ja/`). The wrapper sets the page frontmatter; the component reads `Astro.currentLocale` and looks up its strings.
+
+```astro
+---
+import { defaultLocale, type Locale } from '../i18n/locales'
+import { aboutTranslations } from '../i18n/aboutTranslations'
+
+const locale = (Astro.currentLocale ?? defaultLocale) as Locale
+const t = aboutTranslations[locale]
+---
+<h2>{t.page_title}</h2>
+```
+
+Locale identifiers are centralized in `src/i18n/locales.ts` (`locales`, `defaultLocale`, `Locale`). Use this module for any new locale-aware code instead of hard-coding `'en' | 'es' | 'ja'`.
 
 ### Design tokens
 
@@ -68,7 +81,28 @@ Alternate `.pip-grn` (green) and `.pip-teal` (teal) across acts to create visual
 
 ---
 
+## i18n Translation Tables
+
+Hand-crafted editorial pages — **About, Features, Contest, the Home hero/feature copy, and the Fraud Report form** — read all of their copy from per-page translation tables in `src/i18n/`. These tables are flat objects keyed by locale (`en` / `es` / `ja`) with string values for each text slot.
+
+| File | Drives |
+| :--- | :----- |
+| `src/i18n/locales.ts` | `locales`, `defaultLocale`, `Locale` type — single source of truth for locale identifiers |
+| `src/i18n/indexTranslations.ts` | Home page: hero, network section, five feature blurbs, stats heading |
+| `src/i18n/aboutTranslations.ts` | All copy on the About page (page title, chips, three acts) |
+| `src/i18n/featuresTranslations.ts` | All copy on the Features page (chips, three acts: Protocol / Finance / Governance) |
+| `src/i18n/contestTranslations.ts` | All copy on the Contest page |
+| `src/i18n/fraudReportTranslations.ts` | Fraud Report intro, form, privacy, attribution, error messages |
+
+Adding or changing copy means editing one of these files — components do not need to change. Keys are flat (e.g. `proto_h3_line1`, `feat3_desc`) so that a missing translation is a quick visual diff against the English block.
+
+`src/data/about.json` and `src/data/features.json` remain in the tree as historical artefacts. The live About and Features components no longer read from them.
+
+---
+
 ## JSON Data Files
+
+JSON drives list-shaped pages where the content has uniform structure (stats, events, ecosystem entries, roadmap items). Each entry's translatable strings are keyed by locale inline.
 
 ### `src/data/home.json`
 
@@ -95,56 +129,6 @@ Controls the statistics tiles on the home page (`XahauHome.astro`).
 | `col` | number | Column span within the 9-column grid |
 
 **Grid rule:** `col` values for each visual row must sum to **9**. Current layout: row 1 = 5 + 4, row 2 = 3 + 3 + 3.
-
----
-
-### `src/data/about.json`
-
-Drives `XahauAbout.astro` (and ES/JA variants). Top-level structure:
-
-```json
-{
-  "meta": {
-    "videoId": "4pruN6sWJho",
-    "launched": "October 2023",
-    "accounts": "100k+",
-    "settlement": "~4s"
-  },
-  "content": {
-    "en": { "title": "...", "subtitle": "...", "chips": [], "intro": {}, "acts": [] },
-    "es": { ... },
-    "ja": { ... }
-  }
-}
-```
-
-Each locale object contains `title`, `subtitle`, `chips[]`, `intro` (label + paragraphs), and `acts[]` (the three thematic acts: Network, Protocol, Currency), each with headings, paragraphs, and graphic keys mapping to SVGs in `src/assets/enterprise/`.
-
----
-
-### `src/data/features.json`
-
-Drives `XahauFeatures.astro` (and ES/JA variants). The `content` object is keyed by locale. Each locale has `title`, `subtitle`, `chips[]`, and `features[]`:
-
-```json
-{
-  "id": "hooks",
-  "label": "Programmability",
-  "type": "protocol",
-  "graphic": "hooks",
-  "heading": "Hooks: Account-Level Smart Contract Logic",
-  "paragraphs": ["...", "..."]
-}
-```
-
-| Field | Description |
-| :---- | :---------- |
-| `id` | Unique slug (used for anchor links) |
-| `label` | Short label shown in the sidebar nav |
-| `type` | Visual category tag: `"protocol"`, `"finance"`, or `"infrastructure"` |
-| `graphic` | Key mapping to an SVG in `src/assets/enterprise/` |
-| `heading` | Full section heading |
-| `paragraphs` | Array of body paragraph strings |
 
 ---
 
@@ -208,7 +192,51 @@ Valid `status` values: `"done"`, `"in-progress"`, `"planned"`, `"research"`.
 
 ### `src/data/ecosystem.json`
 
-Drives `XahauEcosystem.astro`. Contains the ecosystem project list with logos, categories, and external links. Logo image files go in `src/assets/ecosystem-logos/`.
+Drives `XahauEcosystem.astro`. Contains the ecosystem project list (Enterprises, Wallets, Exchanges, Explorers & Utilities, Projects) with section labels, taglines, logos, and external links. Logo image files go in `src/assets/ecosystem-logos/`.
+
+A top-level `trademark` object provides the localized footer disclaimer:
+
+```json
+"trademark": {
+  "en": "All trademarks and logos are the property of their respective owners.",
+  "es": "Todas las marcas y logotipos son propiedad de sus respectivos dueños.",
+  "ja": "すべての商標およびロゴは、各所有者に帰属します"
+}
+```
+
+---
+
+## Cookie Consent
+
+The site uses [vanilla-cookieconsent](https://cookieconsent.orestbida.com/) to show a GDPR-compliant banner. The component (`src/components/CookieConsent.astro`) is mounted in the base layout. Categories, button labels, and per-locale strings live in `src/CookieConsentConfig.ts` — adding a locale means adding a `translations` block keyed by the locale code in that file.
+
+---
+
+## Plugins, Schemas, Utils
+
+Three small directories support the rest of the codebase:
+
+- **`src/plugins/remarkGlobalReferences.ts`** — Remark plugin used by Astro's MDX pipeline (wired up in `astro.config.mjs` under `markdown.remarkPlugins`). Resolves shared `[label]` reference-link definitions across all docs files.
+- **`src/schemas/roadmap.ts`** — Zod schema validating `src/data/roadmap.json` at build time, plus the exported `RoadmapItem` type used by `XahauRoadmap.astro`.
+- **`src/schemas/dataapi.json`** — OpenAPI schema fed to `starlight-openapi` to generate the Data API reference.
+- **`src/utils/localizedHref.ts`** — Helper for building locale-prefixed internal links (e.g. `/es/about`, `/ja/about`). Use this instead of hand-concatenating locale prefixes.
+
+---
+
+## Pre-commit Hooks
+
+[Lefthook](https://github.com/evilmartians/lefthook) runs the Biome formatter on staged files before each commit. Configuration lives in `lefthook.yml` at the repo root. After cloning:
+
+```bash
+npm install
+npx lefthook install
+```
+
+To run the hooks manually:
+
+```bash
+npx lefthook run pre-commit
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Built with [Astro](https://astro.build), [Tailwind CSS](https://tailwindcss.com)
 
 ## Pre-commit Hooks
 
-The project uses [Lefthook](https://github.com/evilmartians/lefthook) to run pre-commit hooks. The hooks are defined in the `.lefthook.yml` file.
+The project uses [Lefthook](https://github.com/evilmartians/lefthook) to run pre-commit hooks. The hooks are defined in the `lefthook.yml` file.
 
 To install the hooks, use the following command (npm install is required):
 
@@ -43,13 +43,17 @@ npx lefthook run pre-commit
 ├── public/                   Static assets (fonts, favicons)
 ├── src/
 │   ├── assets/               SVGs, images, gem PNGs
-│   ├── components/           Astro & React components
+│   ├── components/           Astro & React components (incl. CookieConsent.astro)
 │   ├── content/docs/         Starlight documentation (Markdown/MDX)
-│   ├── data/                 JSON data files — edit these to update content
-│   ├── i18n/                 Translation keys for the home page
+│   ├── data/                 JSON data files (home, connect, ecosystem, roadmap)
+│   ├── i18n/                 Per-page translation tables + locales.ts
 │   ├── layouts/              Page-level layout wrappers
 │   ├── pages/                URL routes (en = root, es/, ja/)
-│   └── styles/               Global CSS and Tailwind theme tokens
+│   ├── plugins/              Remark/MDX plugins (e.g. global references)
+│   ├── schemas/              Zod schemas + JSON schemas for typed data
+│   ├── styles/               Global CSS and Tailwind theme tokens
+│   ├── utils/                Shared helpers (e.g. localizedHref)
+│   └── CookieConsentConfig.ts  vanilla-cookieconsent configuration
 ├── biome.jsonc               Linter/formatter config (Biome 2.4)
 └── astro.config.mjs          Astro config (i18n, integrations)
 ```
@@ -58,22 +62,48 @@ npx lefthook run pre-commit
 
 ## Localization
 
-The site supports three locales: English (root `/`), Spanish (`/es/`), and Japanese (`/ja/`). Each editorial page has a dedicated component per locale — e.g. `XahauAbout.astro`, `XahauAboutEs.astro`, `XahauAboutJa.astro` — with a thin `.astro` page wrapper in `src/pages/` for each. To add a new language, follow the steps in [ADDING-A-LOCALE.md](ADDING-A-LOCALE.md).
+The site supports three locales: English (root `/`), Spanish (`/es/`), and Japanese (`/ja/`). All three are fully enabled in production.
+
+Each editorial page is a **single component** that reads its copy from a per-page translation table in `src/i18n/` (e.g. `aboutTranslations.ts`, `featuresTranslations.ts`, `contestTranslations.ts`, `indexTranslations.ts`, `fraudReportTranslations.ts`). The component picks the active locale via `Astro.currentLocale` and looks up strings against the table — there are no per-locale component variants.
+
+Locale identifiers are centralized in `src/i18n/locales.ts` (`locales`, `defaultLocale`, `Locale` type). Each route is a thin `.astro` wrapper under `src/pages/`, `src/pages/es/`, and `src/pages/ja/` that imports the shared component.
+
+To add a new language, follow the steps in [ADDING-A-LOCALE.md](ADDING-A-LOCALE.md).
 
 ---
 
 ## Updating Content
 
-Most editorial page content is stored in JSON files under `src/data/`. **Edit the JSON to change what's rendered — no component code changes needed.** See [DEVELOPMENT.md](DEVELOPMENT.md) for the full schema of each file.
+Content lives in two places, depending on the page:
+
+**JSON data files** (`src/data/`) drive list-shaped pages — home stats, events, ecosystem entries, roadmap items. Edit the JSON to change what's rendered; no component changes needed.
 
 | File | Controls |
 | :--- | :------- |
 | `src/data/home.json` | Statistics tiles on the home page |
-| `src/data/about.json` | All copy and section structure on the About page |
-| `src/data/features.json` | Feature cards and body copy on the Features page |
 | `src/data/connect.json` | Events list on the Connect page |
 | `src/data/roadmap.json` | Roadmap items and quarter window |
 | `src/data/ecosystem.json` | Ecosystem project list |
+
+**i18n translation tables** (`src/i18n/*Translations.ts`) drive hand-crafted editorial pages — About, Features, Contest, the home hero/feature copy, and the Fraud Report form. Each table is keyed by locale (`en` / `es` / `ja`); add or update strings under the right locale and the matching component picks them up.
+
+| File | Controls |
+| :--- | :------- |
+| `src/i18n/aboutTranslations.ts` | All copy on the About page |
+| `src/i18n/featuresTranslations.ts` | All copy on the Features page |
+| `src/i18n/contestTranslations.ts` | All copy on the Contest page |
+| `src/i18n/indexTranslations.ts` | Home hero + feature blurbs |
+| `src/i18n/fraudReportTranslations.ts` | Fraud Report form labels |
+
+See [DEVELOPMENT.md](DEVELOPMENT.md) for the full schema of each file.
+
+A few historical `src/data/about.json` / `features.json` files still exist; the live About and Features components no longer read from them — translations are the source of truth.
+
+---
+
+## Cookie Consent
+
+The site uses [vanilla-cookieconsent](https://cookieconsent.orestbida.com/) for GDPR-compliant cookie banners. The component lives in `src/components/CookieConsent.astro` and the category/translation config is in `src/CookieConsentConfig.ts`.
 
 ---
 


### PR DESCRIPTION
… consolidation

- README: rewrite Localization + Updating Content sections; add Cookie Consent; expand Project Structure (plugins/, schemas/, utils/)
- DEVELOPMENT: drop per-locale component map rows; add i18n Translation Tables section; drop stale about.json/features.json schemas; add Cookie Consent, plugins/schemas/utils, and pre-commit sections
- ADDING-A-LOCALE: replace per-locale-component flow with single-component + translation-table flow; add locales.ts step; move TM disclaimer to ecosystem.json; drop XahauAboutPtBR.astro step
- Fix lefthook.yml filename (no leading dot)